### PR TITLE
feat: Update theme toggle to use emojis and fix download button

### DIFF
--- a/script.js
+++ b/script.js
@@ -188,7 +188,7 @@ body[data-theme='dark'] .theme-toggle:hover {
     function applyTheme(theme) {
         document.body.dataset.theme = theme;
         if (themeToggleButton) {
-            themeToggleButton.textContent = theme === 'dark' ? 'Set Light Theme' : 'Set Dark Theme';
+            themeToggleButton.innerHTML = theme === 'dark' ? '☀️' : '🌙';
         }
     }
 
@@ -223,6 +223,7 @@ body[data-theme='dark'] .theme-toggle:hover {
     const urlStatusDisplay = document.getElementById('urlStatus');
     const outputArea = document.getElementById('output');
     const copyButton = document.getElementById('copyButton');
+    const downloadButton = document.getElementById('downloadButton');
     const filterModeSelect = document.getElementById('filterMode');
     const filterPatternsInput = document.getElementById('filterPatterns');
     const maxSizeSlider = document.getElementById('maxSizeSlider');
@@ -275,6 +276,9 @@ body[data-theme='dark'] .theme-toggle:hover {
     folderInput.addEventListener('change', handleFolderSelect);
     fetchUrlButton.addEventListener('click', handleUrlFetch); // New handler for URL fetch
     copyButton.addEventListener('click', copyOutputToClipboard);
+    if (downloadButton) {
+        downloadButton.addEventListener('click', downloadOutput);
+    }
     maxSizeSlider.addEventListener('input', updateMaxSize);
     filterModeSelect.addEventListener('change', () => { currentFilterMode = filterModeSelect.value; });
 


### PR DESCRIPTION
This commit introduces two main improvements:

1.  Theme Toggle Emojis:
    - The theme toggle button now displays emojis instead of text.
    - It shows ☀️ when the current theme is dark (to switch to light).
    - It shows 🌙 when the current theme is light (to switch to dark).

2.  Download Button Functionality:
    - The "Download Output" button is now functional.
    - It downloads the content of the "Combined Output" textarea as a `code_output.txt` file.
    - If the output area is empty, no download is initiated.